### PR TITLE
 #565: Removed the ability to copy a separate set of records when validation passes

### DIFF
--- a/src/main/java/eu/cessda/cmv/console/Configuration.java
+++ b/src/main/java/eu/cessda/cmv/console/Configuration.java
@@ -19,7 +19,6 @@ import java.nio.file.Path;
 
 public record Configuration(
     Path rootDirectory,
-    Path destinationDirectory,
-    Path wrappedDirectory
+    Path destinationDirectory
 ) {
 }

--- a/src/test/java/eu/cessda/cmv/console/ValidatorTest.java
+++ b/src/test/java/eu/cessda/cmv/console/ValidatorTest.java
@@ -38,7 +38,7 @@ class ValidatorTest {
     private final Configuration configuration;
 
     ValidatorTest() {
-        configuration = new Configuration(Path.of("input"), null, null);
+        configuration = new Configuration(Path.of("input"), null);
     }
 
     @Test


### PR DESCRIPTION
Given that after https://github.com/cessda/cessda.metadata.harvester/pull/24 is merged there won't be any unwrapped records, the code to copy them can be removed.

See https://github.com/cessda/cessda.cdc.versions/issues/565 for more context.