### PR TITLE
#635: Report details about valid persistent identifiers in addition to invalid persistent identifiers

### DIFF
--- a/src/main/java/eu/cessda/cmv/console/PIDValidationResult.java
+++ b/src/main/java/eu/cessda/cmv/console/PIDValidationResult.java
@@ -17,5 +17,5 @@ package eu.cessda.cmv.console;
 
 import java.util.List;
 
-record PIDValidationResult(boolean valid, List<PID> invalidPIDs) {
+record PIDValidationResult(boolean valid, List<PID> validPIDs, List<PID> invalidPIDs) {
 }

--- a/src/test/java/eu/cessda/cmv/console/PIDValidatorTest.java
+++ b/src/test/java/eu/cessda/cmv/console/PIDValidatorTest.java
@@ -30,17 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class PIDValidatorTest {
 
-
-    @Test
-    void shouldValidatePIDs() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
-        var validDDIDocument = getDocumentBuilder().parse(this.getClass().getResourceAsStream("/ddi_2_5/pid.xml"));
-
-        var validationResult = PIDValidator.validatePIDs(validDDIDocument, DDIVersion.DDI_2_5);
-
-        // Assert that the document was treated as valid and that 2 PIDs were validated
-        assertTrue(validationResult.valid());
-        assertEquals(2, validationResult.invalidPIDs().size());
-    }
+    private final PIDValidator pidValidator = new PIDValidator();
 
     private static DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
         var factory = DocumentBuilderFactory.newInstance();
@@ -49,10 +39,21 @@ class PIDValidatorTest {
     }
 
     @Test
+    void shouldValidatePIDs() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        var validDDIDocument = getDocumentBuilder().parse(this.getClass().getResourceAsStream("/ddi_2_5/pid.xml"));
+
+        var validationResult = pidValidator.validatePIDs(validDDIDocument, DDIVersion.DDI_2_5);
+
+        // Assert that the document was treated as valid and that 2 PIDs were validated
+        assertTrue(validationResult.valid());
+        assertEquals(2, validationResult.invalidPIDs().size());
+    }
+
+    @Test
     void shouldReportInvalidPIDs() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
         var invalidDDIDocument = getDocumentBuilder().parse(this.getClass().getResourceAsStream("/ddi_2_5/invalid.xml"));
 
-        var validationResult = PIDValidator.validatePIDs(invalidDDIDocument, DDIVersion.DDI_2_5);
+        var validationResult = pidValidator.validatePIDs(invalidDDIDocument, DDIVersion.DDI_2_5);
 
         // Assert that no valid PIDs are found
         assertFalse(validationResult.valid());
@@ -66,7 +67,7 @@ class PIDValidatorTest {
     void shouldValidatePIDsInDDI3Document() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
         var validDDIDocument = getDocumentBuilder().parse(this.getClass().getResourceAsStream("/ddi_3_2/valid.xml"));
 
-        var validationResult = PIDValidator.validatePIDs(validDDIDocument, DDIVersion.DDI_3_2);
+        var validationResult = pidValidator.validatePIDs(validDDIDocument, DDIVersion.DDI_3_2);
 
         // Assert that the document was treated as valid and that 2 PIDs were validated
         assertTrue(validationResult.valid());

--- a/src/test/java/eu/cessda/cmv/console/PIDValidatorTest.java
+++ b/src/test/java/eu/cessda/cmv/console/PIDValidatorTest.java
@@ -46,7 +46,8 @@ class PIDValidatorTest {
 
         // Assert that the document was treated as valid and that 2 PIDs were validated
         assertTrue(validationResult.valid());
-        assertEquals(2, validationResult.invalidPIDs().size());
+        assertEquals(1, validationResult.validPIDs().size());
+        assertEquals(1, validationResult.invalidPIDs().size());
     }
 
     @Test
@@ -71,7 +72,8 @@ class PIDValidatorTest {
 
         // Assert that the document was treated as valid and that 2 PIDs were validated
         assertTrue(validationResult.valid());
-        assertEquals(2, validationResult.invalidPIDs().size());
+        assertEquals(1, validationResult.validPIDs().size());
+        assertEquals(1, validationResult.invalidPIDs().size());
     }
 
     @Test


### PR DESCRIPTION
This commit also caches the XPath instance used to compile XPaths.

This closes cessda/cessda.cdc.versions#635