### PR TITLE
#635: Separate PID report into separate arrays

### DIFF
--- a/src/main/java/eu/cessda/cmv/console/Validator.java
+++ b/src/main/java/eu/cessda/cmv/console/Validator.java
@@ -376,7 +376,7 @@ public class Validator {
             var validPIDAgency = new ArrayList<String>();
             for (var validPID : report.pidValidationResult().validPIDs()) {
                 validPIDAgency.add(validPID.agency());
-                validPIDAgency.add(validPID.uri());
+                validPIDURIs.add(validPID.uri());
             }
 
             var invalidPIDAgency = new ArrayList<String>();


### PR DESCRIPTION
This is to work around how Elasticsearch flattens arrays when ingesting the logs.

See cessda/cessda.cdc.versions#635