### PR TITLE
Update CMV Core to version 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>eu.cessda.cmv</groupId>
             <artifactId>cmv-core</artifactId>
-            <version>2.0.0</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- JSON Encoder -->
@@ -79,15 +79,20 @@
 
         <!-- Logging -->
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.6</version>
+        </dependency>
+        <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.3</version>
+            <version>7.4</version>
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>eu.cessda.cmv</groupId>
             <artifactId>cmv-core</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
 
         <!-- JSON Encoder -->

--- a/src/main/java/eu/cessda/cmv/console/ProfileLoadFailedException.java
+++ b/src/main/java/eu/cessda/cmv/console/ProfileLoadFailedException.java
@@ -15,19 +15,22 @@
  */
 package eu.cessda.cmv.console;
 
-import java.io.IOException;
+import java.io.Serial;
 import java.util.Objects;
 
 /**
  * Thrown when an IO error prevents the CMV profile from being loaded.
  */
 public class ProfileLoadFailedException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = -2846516401063112182L;
+
     /**
      * Constructs a new {@link ProfileLoadFailedException} with the specified cause.
      *
      * @param e the cause, must not be null.
      */
-    public ProfileLoadFailedException(IOException e) {
+    public ProfileLoadFailedException(Throwable e) {
         super(Objects.requireNonNull(e, "exception must not be null"));
     }
 }

--- a/src/main/java/eu/cessda/cmv/console/ProfileValidator.java
+++ b/src/main/java/eu/cessda/cmv/console/ProfileValidator.java
@@ -17,65 +17,49 @@ package eu.cessda.cmv.console;
 
 import eu.cessda.cmv.core.CessdaMetadataValidatorFactory;
 import eu.cessda.cmv.core.NotDocumentException;
+import eu.cessda.cmv.core.Profile;
 import eu.cessda.cmv.core.ValidationGateName;
-import eu.cessda.cmv.core.ValidationService;
 import eu.cessda.cmv.core.mediatype.validationreport.ValidationReport;
-import org.gesis.commons.resource.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ProfileValidator {
-    private final ValidationService validationService = new CessdaMetadataValidatorFactory().newValidationService();
+    private static final Logger log = LoggerFactory.getLogger(ProfileValidator.class);
+
+    /**
+     * Validator factory, creates the CMV documents and profiles
+     */
+    private final CessdaMetadataValidatorFactory validatorFactory = new CessdaMetadataValidatorFactory();
+
     /**
      * Cache for CMV profiles
      */
-    private final ConcurrentHashMap<URI, Resource> profileMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<URI, Profile> profileMap = new ConcurrentHashMap<>();
 
     /**
      * Validate the given XML document against a DDI profile.
      *
-     * @param document       the document to validate
-     * @param profile        the profile to validate the document against
+     * @param documentStream the document to validate
+     * @param profileURI     the profile to validate the document against
      * @param validationGate the validation gate to use
      * @return the validation report
      */
-    public ValidationReport validateAgainstProfile(Resource document, URI profile, ValidationGateName validationGate) throws IOException, NotDocumentException {
+    public ValidationReport validateAgainstProfile(InputStream documentStream, URI profileURI, ValidationGateName validationGate) throws IOException, NotDocumentException {
         // Load and cache the DDI profile
-        var profileResource = profileMap.computeIfAbsent(profile, CachedProfileResource::new);
-        return validationService.validate(document, profileResource, validationGate);
-    }
-
-    private static class CachedProfileResource implements Resource {
-        private final URI source;
-        private final byte[] buffer;
-
-        /**
-         * Create a new instance of a CachedProfileResource, reading the URL into a buffer.
-         *
-         * @param source the URI of the profile.
-         * @throws ProfileLoadFailedException if an IO error occurred.
-         */
-        private CachedProfileResource(URI source) {
-            this.source = source;
-            try (var inputStream = source.toURL().openStream()) {
-                this.buffer = inputStream.readAllBytes();
-            } catch (IOException e) {
+        var profile = profileMap.computeIfAbsent(profileURI, p -> {
+            try {
+                log.debug("Parsing CMV profile \"{}\"", p);
+                return validatorFactory.newProfile(p);
+            } catch (NotDocumentException | IOException e) {
                 throw new ProfileLoadFailedException(e);
             }
-        }
-
-        @Override
-        public URI getUri() {
-            return source;
-        }
-
-        @Override
-        public InputStream readInputStream() {
-            return new ByteArrayInputStream(buffer);
-        }
+        });
+        var document = validatorFactory.newDocument(documentStream);
+        return validatorFactory.validate(document, profile, validationGate);
     }
 }

--- a/src/test/java/eu/cessda/cmv/console/ProfileValidatorTest.java
+++ b/src/test/java/eu/cessda/cmv/console/ProfileValidatorTest.java
@@ -17,7 +17,6 @@ package eu.cessda.cmv.console;
 
 import eu.cessda.cmv.core.NotDocumentException;
 import eu.cessda.cmv.core.ValidationGateName;
-import org.gesis.commons.resource.Resource;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -37,7 +36,7 @@ class ProfileValidatorTest {
         assert document != null;
 
         var results = profileValidator.validateAgainstProfile(
-            Resource.newResource(document), this.getClass().getResource("/profiles/cdc-ddi2.5.xml").toURI(), ValidationGateName.BASIC
+            document, this.getClass().getResource("/profiles/cdc-ddi2.5.xml").toURI(), ValidationGateName.BASIC
         );
 
         assertTrue(results.getConstraintViolations().isEmpty());
@@ -50,10 +49,9 @@ class ProfileValidatorTest {
 
         // Empty input stream, should not be consumed.
         var nullInputStream = InputStream.nullInputStream();
-        var nullResource = Resource.newResource(nullInputStream);
 
         assertThrows(ProfileLoadFailedException.class, () ->
-            profileValidator.validateAgainstProfile(nullResource, uri, ValidationGateName.BASIC)
+            profileValidator.validateAgainstProfile(nullInputStream, uri, ValidationGateName.BASIC)
         );
     }
 }


### PR DESCRIPTION
CMV Core 3.0.0 has significant performance improvements and allows profiles to be cached, reducing time that the application has to spend parsing the profiles.

This PR also fixes a bug preventing the invalid records counter from counting properly.